### PR TITLE
Add auto-clear chat on panel open

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -120,6 +120,26 @@
       <label>Internal: incremented when API key is saved to KDE Wallet</label>
       <default>0</default>
     </entry>
+    <entry name="autoClearMode" type="Int">
+      <label>Auto-clear mode: 0=disabled, 1=instant, 2=seconds, 3=minutes</label>
+      <default>0</default>
+    </entry>
+    <entry name="autoClearSeconds" type="Int">
+      <label>Auto-clear threshold in seconds</label>
+      <default>30</default>
+      <min>1</min>
+      <max>3600</max>
+    </entry>
+    <entry name="autoClearMinutes" type="Int">
+      <label>Auto-clear threshold in minutes</label>
+      <default>5</default>
+      <min>1</min>
+      <max>1440</max>
+    </entry>
+    <entry name="lastClosedTimestamp" type="String">
+      <label>Unix ms timestamp when panel was last closed (runtime)</label>
+      <default></default>
+    </entry>
   </group>
 
 </kcfg>

--- a/package/contents/ui/configGeneral.qml
+++ b/package/contents/ui/configGeneral.qml
@@ -68,6 +68,14 @@ SimpleKCM {
     property bool cfg_sysInfoLocaleDefault
     property int cfg_apiKeyVersion
     property int cfg_apiKeyVersionDefault
+    property int cfg_autoClearMode
+    property int cfg_autoClearModeDefault
+    property int cfg_autoClearSeconds
+    property int cfg_autoClearSecondsDefault
+    property int cfg_autoClearMinutes
+    property int cfg_autoClearMinutesDefault
+    property string cfg_lastClosedTimestamp
+    property string cfg_lastClosedTimestampDefault
 
     property var availableModels: []
     property string walletApiKey: ""
@@ -465,6 +473,56 @@ SimpleKCM {
             text: "Saves to ~/PlasmaLLM/chats/"
             font: Kirigami.Theme.smallFont
             color: Kirigami.Theme.disabledTextColor
+        }
+
+        QQC2.ButtonGroup { id: autoClearGroup }
+
+        ColumnLayout {
+            Kirigami.FormData.label: "Auto-clear:"
+            spacing: Kirigami.Units.smallSpacing
+
+            QQC2.RadioButton {
+                text: "Disabled"
+                QQC2.ButtonGroup.group: autoClearGroup
+                checked: cfg_autoClearMode === 0
+                onClicked: cfg_autoClearMode = 0
+            }
+            QQC2.RadioButton {
+                text: "Instant (always clear when panel opens)"
+                QQC2.ButtonGroup.group: autoClearGroup
+                checked: cfg_autoClearMode === 1
+                onClicked: cfg_autoClearMode = 1
+            }
+            RowLayout {
+                spacing: Kirigami.Units.smallSpacing
+                QQC2.RadioButton {
+                    QQC2.ButtonGroup.group: autoClearGroup
+                    checked: cfg_autoClearMode === 2
+                    onClicked: cfg_autoClearMode = 2
+                }
+                QQC2.SpinBox {
+                    from: 1; to: 3600
+                    value: cfg_autoClearSeconds
+                    onValueModified: cfg_autoClearSeconds = value
+                    enabled: cfg_autoClearMode === 2
+                }
+                QQC2.Label { text: "seconds" }
+            }
+            RowLayout {
+                spacing: Kirigami.Units.smallSpacing
+                QQC2.RadioButton {
+                    QQC2.ButtonGroup.group: autoClearGroup
+                    checked: cfg_autoClearMode === 3
+                    onClicked: cfg_autoClearMode = 3
+                }
+                QQC2.SpinBox {
+                    from: 1; to: 1440
+                    value: cfg_autoClearMinutes
+                    onValueModified: cfg_autoClearMinutes = value
+                    enabled: cfg_autoClearMode === 3
+                }
+                QQC2.Label { text: "minutes" }
+            }
         }
 
         QQC2.CheckBox {

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -639,4 +639,24 @@ PlasmoidItem {
         regatherSysInfo();
         loadApiKeyFromWallet();
     }
+
+    onExpandedChanged: function(expanded) {
+        if (!expanded) {
+            Plasmoid.configuration.lastClosedTimestamp = String(Date.now())
+        } else {
+            var mode = Plasmoid.configuration.autoClearMode
+            if (mode === 1) {
+                clearChat()
+            } else if (mode === 2 || mode === 3) {
+                var lastClosed = parseInt(Plasmoid.configuration.lastClosedTimestamp) || 0
+                if (lastClosed > 0) {
+                    var elapsed = Date.now() - lastClosed
+                    var threshold = mode === 2
+                        ? Plasmoid.configuration.autoClearSeconds * 1000
+                        : Plasmoid.configuration.autoClearMinutes * 60 * 1000
+                    if (elapsed >= threshold) clearChat()
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Adds a configurable policy to clear the chat when the panel is expanded after a period of inactivity. Four modes: disabled (default), instant (always clear on open), clear after N seconds, or clear after N minutes.

On close, the current timestamp is stored in config. On open, the elapsed time is compared against the threshold and clearChat() is called if met.