### PR TITLE
Add Auto mode: session toggle, /auto command, and AUTO badge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,3 +73,9 @@ There is no build step, test suite, or linter. QML is interpreted at runtime. Af
 
 - When intending to run multiple commands, create a script file and execute that instead of one at a time
 - After making changes, run the install script and restart Plasma
+
+## Git Workflow
+
+- **Never push directly to `master`**. Always create a feature branch and open a PR.
+- **Never commit or push unless explicitly asked.** Make changes, then wait for the user to review and say when to commit and when to push.
+- Branch naming: `feature/<short-description>` or `fix/<short-description>`

--- a/package/contents/ui/FullRepresentation.qml
+++ b/package/contents/ui/FullRepresentation.qml
@@ -15,6 +15,7 @@ PlasmaExtras.Representation {
     id: fullRep
 
     readonly property var slashCommands: [
+        { cmd: "/auto",     desc: "Toggle auto mode (auto-run + auto-share) for this session" },
         { cmd: "/clear",    desc: "Clear the chat" },
         { cmd: "/copy",     desc: "Copy conversation to clipboard" },
         { cmd: "/history",  desc: "Open chat history folder" },
@@ -64,6 +65,16 @@ PlasmaExtras.Representation {
                 }
                 font.bold: true
                 elide: Text.ElideRight
+            }
+
+            PlasmaComponents.Label {
+                text: "AUTO"
+                visible: root.isAutoMode
+                font.bold: true
+                color: Kirigami.Theme.negativeTextColor
+                PlasmaComponents.ToolTip.text: "Auto mode active — commands run and share output automatically"
+                PlasmaComponents.ToolTip.delay: Kirigami.Units.toolTipDelay
+                PlasmaComponents.ToolTip.visible: hovered
             }
 
             PlasmaComponents.ToolButton {

--- a/package/contents/ui/api.js
+++ b/package/contents/ui/api.js
@@ -69,6 +69,12 @@ function buildSystemPrompt(sysInfo, customAdditions, options) {
             "Inline code (`` ` ``) does not auto-run.\n";
     }
 
+    if (options && options.autoMode) {
+        prompt += "\n## Full Auto mode is ACTIVE\n" +
+            "Commands run AND their output is automatically shared back to you. " +
+            "You are in an agentic loop. Prefer read-only commands unless the user explicitly requests a write operation.\n";
+    }
+
     if (customAdditions && customAdditions.trim().length > 0) {
         prompt += "The below instructions are given by the user and take the utmost precedence over the instructions above.\n";
         prompt += "\n" + customAdditions.trim() + "\n";


### PR DESCRIPTION
Introduces a combined auto-run + auto-share mode controllable either via the /auto slash command (per-session) or automatically when both config toggles are enabled. A red "AUTO" badge in the panel header signals when the mode is active, and the system prompt gains an agentic-loop warning section.