### PR TITLE
Add /model slash command with autocomplete and model caching

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -140,6 +140,10 @@
       <label>Unix ms timestamp when panel was last closed (runtime)</label>
       <default></default>
     </entry>
+    <entry name="availableModels" type="String">
+      <label>Fetched model list (JSON array, written at runtime)</label>
+      <default></default>
+    </entry>
   </group>
 
 </kcfg>

--- a/package/contents/ui/configGeneral.qml
+++ b/package/contents/ui/configGeneral.qml
@@ -76,6 +76,8 @@ SimpleKCM {
     property int cfg_autoClearMinutesDefault
     property string cfg_lastClosedTimestamp
     property string cfg_lastClosedTimestampDefault
+    property string cfg_availableModels
+    property string cfg_availableModelsDefault
 
     property var availableModels: []
     property string walletApiKey: ""
@@ -268,6 +270,9 @@ SimpleKCM {
             Layout.fillWidth: true
             text: cfg_apiEndpoint
             onTextChanged: {
+                cfg_availableModels = "";
+                availableModels = [];
+                modelCombo.visible = false;
                 cfg_apiEndpoint = text;
                 // Update preset selector if it no longer matches
                 var matched = false;
@@ -315,6 +320,7 @@ SimpleKCM {
                             fetchStatusLabel.visible = true;
                         } else {
                             availableModels = models;
+                            cfg_availableModels = JSON.stringify(models);
                             modelCombo.visible = true;
                             fetchStatusLabel.visible = false;
                         }


### PR DESCRIPTION
- New `availableModels` config entry persists fetched model list as JSON
- configGeneral: saves list on fetch, clears it when endpoint changes
- main.qml: `/model` shows current model + cached list; `/model <name>` switches model
- FullRepresentation: modelPopup autocompletes model names after `/model `, supports Tab/Enter/Send completion with cursor at end