### PR TITLE
Remove spurious tooltip from AUTO badge

### DIFF
--- a/package/contents/ui/FullRepresentation.qml
+++ b/package/contents/ui/FullRepresentation.qml
@@ -73,9 +73,7 @@ PlasmaExtras.Representation {
                 visible: root.isAutoMode
                 font.bold: true
                 color: Kirigami.Theme.negativeTextColor
-                PlasmaComponents.ToolTip.text: "Auto mode active — commands run and share output automatically"
-                PlasmaComponents.ToolTip.delay: Kirigami.Units.toolTipDelay
-                PlasmaComponents.ToolTip.visible: hovered
+
             }
 
             PlasmaComponents.ToolButton {


### PR DESCRIPTION
The tooltip was showing even when Auto mode was inactive due to hover detection on invisible items in some Plasma/Qt versions. Removed it entirely since the AUTO label and chat message already communicate the mode clearly.