### PR TITLE
Exclude source .po files from .plasmoid package

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -48,6 +48,6 @@ fi
 
 # Build the plasmoid package
 rm -f "$OUTPUT"
-(cd "$PACKAGE_DIR" && zip -r "../$OUTPUT" .)
+(cd "$PACKAGE_DIR" && zip -r "../$OUTPUT" . --exclude "contents/locale/*.po" --exclude "contents/locale/*.pot")
 echo "Created $OUTPUT"
 


### PR DESCRIPTION
.po files not required for compiled package and they just add bloat. Exclude from the package script.