### PR TITLE
Add pin feature to panel

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -164,7 +164,11 @@
       <label>Use tool calling for command execution</label>
       <default>true</default>
     </entry>
-<entry name="tasks" type="String">
+<entry name="pin" type="Bool">
+      <label>Keep panel open when it loses focus</label>
+      <default>false</default>
+    </entry>
+    <entry name="tasks" type="String">
       <label>User-defined tasks (JSON array)</label>
       <default></default>
     </entry>

--- a/package/contents/ui/FullRepresentation.qml
+++ b/package/contents/ui/FullRepresentation.qml
@@ -19,6 +19,7 @@ PlasmaExtras.Representation {
     readonly property var slashCommands: [
         { cmd: "/auto",     desc: i18n("Toggle auto mode (auto-run + auto-share) for this session") },
         { cmd: "/clear",    desc: i18n("Clear the chat") },
+        { cmd: "/close",    desc: i18n("Close the panel") },
         { cmd: "/copy",     desc: i18n("Copy conversation to clipboard") },
         { cmd: "/history",  desc: i18n("Open chat history folder") },
         { cmd: "/model",    desc: i18n("Show or switch model (/model <name>)") },
@@ -162,6 +163,17 @@ PlasmaExtras.Representation {
                 PlasmaComponents.ToolTip.delay: Kirigami.Units.toolTipDelay
                 PlasmaComponents.ToolTip.visible: hovered
                 onClicked: Plasmoid.internalAction("configure").trigger()
+            }
+
+            PlasmaComponents.ToolButton {
+                icon.name: "window-pin"
+                checkable: true
+                checked: Plasmoid.configuration.pin
+                Accessible.name: Plasmoid.configuration.pin ? i18n("Don't keep open") : i18n("Keep open")
+                PlasmaComponents.ToolTip.text: Plasmoid.configuration.pin ? i18n("Don't keep open") : i18n("Keep open")
+                PlasmaComponents.ToolTip.delay: Kirigami.Units.toolTipDelay
+                PlasmaComponents.ToolTip.visible: hovered
+                onClicked: Plasmoid.configuration.pin = !Plasmoid.configuration.pin
             }
         }
     }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -17,6 +17,8 @@ import "api.js" as Api
 PlasmoidItem {
     id: root
 
+    hideOnWindowDeactivate: !Plasmoid.configuration.pin
+
     property bool isLoading: false
     property bool hasUnreadResponse: false
     property var activeRequest: null
@@ -570,6 +572,10 @@ PlasmoidItem {
 
         // Slash commands
         var lower = text.toLowerCase().trim();
+        if (lower === "/close") {
+            root.expanded = false;
+            return;
+        }
         if (lower === "/clear") {
             clearChat();
             return;

--- a/package/metadata.json
+++ b/package/metadata.json
@@ -12,7 +12,7 @@
         "Id": "com.joshuaroman.plasmallm",
         "License": "GPL-2.0-or-later",
         "Name": "PlasmaLLM",
-        "Version": "1.1.0"
+        "Version": "1.1.1"
     },
     "X-Plasma-API-Minimum-Version": "6.0"
 }


### PR DESCRIPTION
Enable the Pin button to keep the panel open when panel loses focus. You can still close the panel by clicking the widget icon again, or use the new "/close" slash command.